### PR TITLE
fix: accelerator_configs var validation

### DIFF
--- a/examples/workbench_complete_example/main.tf
+++ b/examples/workbench_complete_example/main.tf
@@ -17,7 +17,7 @@
 locals {
   location             = "us-central1-a"
   bucket_location      = "us-central1"
-  byod_bucket_name     = "byod-test-bucket"
+  byod_bucket_name     = "byod-test-bucket-${random_id.suffix.hex}"
   metadata_bucket_name = "metadata-bucket"
   labels = {
     env  = "test"

--- a/modules/workbench/outputs.tf
+++ b/modules/workbench/outputs.tf
@@ -58,4 +58,3 @@ output "workbench_name" {
   value       = google_workbench_instance.vertex_ai_workbench.id
   description = "The name of the Vertex AI Workbench instance"
 }
-

--- a/modules/workbench/outputs.tf
+++ b/modules/workbench/outputs.tf
@@ -58,3 +58,4 @@ output "workbench_name" {
   value       = google_workbench_instance.vertex_ai_workbench.id
   description = "The name of the Vertex AI Workbench instance"
 }
+

--- a/modules/workbench/variables.tf
+++ b/modules/workbench/variables.tf
@@ -130,7 +130,7 @@ variable "accelerator_configs" {
   }))
   default = null
   validation {
-    condition     = try(alltrue([for rp in var.accelerator_configs : contains(["NVIDIA_TESLA_P100", "NVIDIA_TESLA_V100", "NVIDIA_TESLA_P4", "NVIDIA_TESLA_T4", "NVIDIA_TESLA_A100", "NVIDIA_A100_80GB", "NVIDIA_L4", "NVIDIA_TESLA_T4_VWS", "NVIDIA_TESLA_P100_VWS", "NVIDIA_TESLA_P4_VWS"], var.accelerator_configs.type)]), false) || var.accelerator_configs == null
+    condition     = try(alltrue([for rp in var.accelerator_configs : contains( ["NVIDIA_TESLA_P100", "NVIDIA_TESLA_V100", "NVIDIA_TESLA_P4", "NVIDIA_TESLA_T4", "NVIDIA_TESLA_A100", "NVIDIA_A100_80GB", "NVIDIA_L4", "NVIDIA_TESLA_T4_VWS", "NVIDIA_TESLA_P100_VWS", "NVIDIA_TESLA_P4_VWS"], rp.type)]), false) || var.accelerator_configs == null
     error_message = "accelerator_configs.type must be one of [NVIDIA_TESLA_P100, NVIDIA_TESLA_V100, NVIDIA_TESLA_P4, NVIDIA_TESLA_T4, NVIDIA_TESLA_A100, NVIDIA_A100_80GB, NVIDIA_L4, NVIDIA_TESLA_T4_VWS, NVIDIA_TESLA_P100_VWS, NVIDIA_TESLA_P4_VWS]"
   }
 }

--- a/modules/workbench/variables.tf
+++ b/modules/workbench/variables.tf
@@ -130,7 +130,7 @@ variable "accelerator_configs" {
   }))
   default = null
   validation {
-    condition     = try(alltrue([for rp in var.accelerator_configs : contains( ["NVIDIA_TESLA_P100", "NVIDIA_TESLA_V100", "NVIDIA_TESLA_P4", "NVIDIA_TESLA_T4", "NVIDIA_TESLA_A100", "NVIDIA_A100_80GB", "NVIDIA_L4", "NVIDIA_TESLA_T4_VWS", "NVIDIA_TESLA_P100_VWS", "NVIDIA_TESLA_P4_VWS"], rp.type)]), false) || var.accelerator_configs == null
+    condition     = try(alltrue([for rp in var.accelerator_configs : contains(["NVIDIA_TESLA_P100", "NVIDIA_TESLA_V100", "NVIDIA_TESLA_P4", "NVIDIA_TESLA_T4", "NVIDIA_TESLA_A100", "NVIDIA_A100_80GB", "NVIDIA_L4", "NVIDIA_TESLA_T4_VWS", "NVIDIA_TESLA_P100_VWS", "NVIDIA_TESLA_P4_VWS"], rp.type)]), false) || var.accelerator_configs == null
     error_message = "accelerator_configs.type must be one of [NVIDIA_TESLA_P100, NVIDIA_TESLA_V100, NVIDIA_TESLA_P4, NVIDIA_TESLA_T4, NVIDIA_TESLA_A100, NVIDIA_A100_80GB, NVIDIA_L4, NVIDIA_TESLA_T4_VWS, NVIDIA_TESLA_P100_VWS, NVIDIA_TESLA_P4_VWS]"
   }
 }


### PR DESCRIPTION
I think there was a mistake in the validation of the accelerator_configs variable, and it’s necessary to check each element of the list.