### PR TITLE
fix: added roles for re-sa for connection ae-agw

### DIFF
--- a/modules/agent-engine-nightly/metadata.yaml
+++ b/modules/agent-engine-nightly/metadata.yaml
@@ -253,4 +253,4 @@ spec:
       - source: hashicorp/google-beta
         version: ">= 7.19, < 8"
       - source: hashicorp/google-nightly
-        version: 5.2.0.27.0
+        version: 5.2.0.27

--- a/modules/agent-engine-nightly/metadata.yaml
+++ b/modules/agent-engine-nightly/metadata.yaml
@@ -196,6 +196,11 @@ spec:
               version: ">= 5.1.6"
             spec:
               outputExpr: "[\"roles/networkservices.admin\", \"roles/modelarmor.user\", \"roles/modelarmor.calloutUser\"]"
+          - source:
+              source: github.com/GoogleCloudPlatform/terraform-google-agent-gateway
+              version: ">= 0.4.1"
+            spec:
+              outputExpr: "[\"roles/modelarmor.user\", \"roles/modelarmor.calloutUser\"]"
     outputs:
       - name: discovery_filter
         description: The pre-formatted filter string to discover this agent in the registry.

--- a/modules/agent-engine-nightly/metadata.yaml
+++ b/modules/agent-engine-nightly/metadata.yaml
@@ -253,4 +253,4 @@ spec:
       - source: hashicorp/google-beta
         version: ">= 7.19, < 8"
       - source: hashicorp/google-nightly
-        version: 5.2.0.27
+        version: 5.2.0.27.0


### PR DESCRIPTION
Added roles for reasoning engine default service account when connection between agent engine - agent gateway

testing= tested through byoc