### PR TITLE
fix!: added wait time for autoregistration of agent in agent registry and remove one output variable

### DIFF
--- a/modules/agent-engine-nightly/README.md
+++ b/modules/agent-engine-nightly/README.md
@@ -54,6 +54,5 @@ output "reasoning_engine_id" {
 | reasoning\_engine\_console\_url | The URL to the Vertex AI Agent Engine console page. |
 | reasoning\_engine\_id | The unique identifier for the Reasoning Engine resource. |
 | reasoning\_engine\_name | The generated name of the Reasoning Engine. |
-| reasoning\_engine\_url | The full regional API URL for the Reasoning Engine interaction. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/agent-engine-nightly/main.tf
+++ b/modules/agent-engine-nightly/main.tf
@@ -173,8 +173,8 @@ resource "google_vertex_ai_reasoning_engine" "main" {
 
 resource "time_sleep" "wait_for_auto_registration_for_agent_in_registry" {
   # Trigger the sleep only after the reasoning engine is fully created
-  depends_on = [google_vertex_ai_reasoning_engine.main]
-  create_duration = "10s" 
+  depends_on      = [google_vertex_ai_reasoning_engine.main]
+  create_duration = "10s"
 }
 
 resource "google_project_service_identity" "aiplatform_identity" {

--- a/modules/agent-engine-nightly/main.tf
+++ b/modules/agent-engine-nightly/main.tf
@@ -174,7 +174,7 @@ resource "google_vertex_ai_reasoning_engine" "main" {
 resource "time_sleep" "wait_for_auto_registration_for_agent_in_registry" {
   # Trigger the sleep only after the reasoning engine is fully created
   depends_on = [google_vertex_ai_reasoning_engine.main]
-  create_duration = "30s" 
+  create_duration = "10s" 
 }
 
 resource "google_project_service_identity" "aiplatform_identity" {

--- a/modules/agent-engine-nightly/main.tf
+++ b/modules/agent-engine-nightly/main.tf
@@ -171,6 +171,12 @@ resource "google_vertex_ai_reasoning_engine" "main" {
   }
 }
 
+resource "time_sleep" "wait_for_auto_registration_for_agent_in_registry" {
+  # Trigger the sleep only after the reasoning engine is fully created
+  depends_on = [google_vertex_ai_reasoning_engine.main]
+  create_duration = "30s" 
+}
+
 resource "google_project_service_identity" "aiplatform_identity" {
   provider = google-beta
   project  = var.project_id

--- a/modules/agent-engine-nightly/metadata.display.yaml
+++ b/modules/agent-engine-nightly/metadata.display.yaml
@@ -83,5 +83,3 @@ spec:
           visibility: VISIBILITY_ROOT
         reasoning_engine_id:
           visibility: VISIBILITY_ROOT
-        reasoning_engine_url:
-          visibility: VISIBILITY_ROOT

--- a/modules/agent-engine-nightly/metadata.yaml
+++ b/modules/agent-engine-nightly/metadata.yaml
@@ -224,8 +224,6 @@ spec:
         description: The unique identifier for the Reasoning Engine resource.
       - name: reasoning_engine_name
         description: The generated name of the Reasoning Engine.
-      - name: reasoning_engine_url
-        description: The full regional API URL for the Reasoning Engine interaction.
   requirements:
     roles:
       - level: Project

--- a/modules/agent-engine-nightly/outputs.tf
+++ b/modules/agent-engine-nightly/outputs.tf
@@ -42,5 +42,5 @@ output "reasoning_engine_console_url" {
 output "discovery_filter" {
   description = "The pre-formatted filter string to discover this agent in the registry."
   value       = format("agentId:\"urn:agent:projects-%s:projects:%s:locations:%s:aiplatform:reasoningEngines:%s\"", data.google_project.project.number, data.google_project.project.number, var.region, google_vertex_ai_reasoning_engine.main.name)
-  depends_on = [time_sleep.wait_for_auto_registration_for_agent_in_registry]
+  depends_on  = [time_sleep.wait_for_auto_registration_for_agent_in_registry]
 }

--- a/modules/agent-engine-nightly/outputs.tf
+++ b/modules/agent-engine-nightly/outputs.tf
@@ -39,11 +39,6 @@ output "reasoning_engine_console_url" {
   value       = "https://console.cloud.google.com/vertex-ai/agents/agent-engines/locations/${var.region}/agent-engines/${google_vertex_ai_reasoning_engine.main.name}/dashboard?project=${var.project_id}"
 }
 
-output "reasoning_engine_url" {
-  description = "The full regional API URL for the Reasoning Engine interaction."
-  value       = "https://${var.region}-aiplatform.googleapis.com/v1/projects/${var.project_id}/locations/${var.region}/reasoningEngines/${google_vertex_ai_reasoning_engine.main.name}"
-}
-
 output "discovery_filter" {
   description = "The pre-formatted filter string to discover this agent in the registry."
   value       = format("agentId:\"urn:agent:projects-%s:projects:%s:locations:%s:aiplatform:reasoningEngines:%s\"", data.google_project.project.number, data.google_project.project.number, var.region, google_vertex_ai_reasoning_engine.main.name)

--- a/modules/agent-engine-nightly/outputs.tf
+++ b/modules/agent-engine-nightly/outputs.tf
@@ -47,4 +47,5 @@ output "reasoning_engine_url" {
 output "discovery_filter" {
   description = "The pre-formatted filter string to discover this agent in the registry."
   value       = format("agentId:\"urn:agent:projects-%s:projects:%s:locations:%s:aiplatform:reasoningEngines:%s\"", data.google_project.project.number, data.google_project.project.number, var.region, google_vertex_ai_reasoning_engine.main.name)
+  depends_on = [time_sleep.wait_for_auto_registration_for_agent_in_registry]
 }

--- a/modules/agent-engine-nightly/versions.tf
+++ b/modules/agent-engine-nightly/versions.tf
@@ -28,6 +28,10 @@ terraform {
       source  = "hashicorp/google-nightly"
       version = "2026.4.8-7.27.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">=0.13.1"
+    }
   }
   required_version = ">= 1.3"
 }


### PR DESCRIPTION
changes:
1. added wait time in output variable (for autoregistration of agent in agent registry).
2. removed reasoning_engine_url output variable

testing details - tested through byoc in private catalog