### PR TITLE
feat: add semantic-governance-policy-engine sub-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a collection of submodules for vertex AI related resources.
 - [Feature Online Store](https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai/tree/main/modules/feature-online-store)
 - [Agent Engine](https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai/tree/main/modules/agent-engine)
 - [Agent Engine (Nightly Build)](https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai/tree/main/modules/agent-engine-nightly)
+- [Semantic Governance Policy Engine](https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai/tree/main/modules/semantic-governance-policy-engine)
 
 ## Requirements
 

--- a/examples/semantic-governance-policy-engine-example/README.md
+++ b/examples/semantic-governance-policy-engine-example/README.md
@@ -1,0 +1,38 @@
+# Semantic Governance Policy Engine example
+
+This example provisions a [Semantic Governance Policy Engine](https://cloud.google.com/gemini-enterprise-agent-platform/govern/policies/semantic-governance-overview) in a single region using the `semantic-governance-policy-engine` module.
+
+Provisioning is a long-running operation (typically a few minutes, up to ~20), and `terraform destroy` triggers an asynchronous deprovision.
+
+## Usage
+
+To run this example execute:
+
+```bash
+export TF_VAR_project_id="your_project_id"
+```
+
+```tf
+terraform init
+terraform plan
+terraform apply
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The ID of the project in which the resource belongs | `string` | n/a | yes |
+| region | The region in which to provision the Semantic Governance Policy Engine | `string` | `"us-central1"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | The engine identifier |
+| project\_id | The project ID |
+| psc\_service\_attachment | The Private Service Connect service attachment URI for the engine's managed endpoint |
+| state | The current state of the engine |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/semantic-governance-policy-engine-example/main.tf
+++ b/examples/semantic-governance-policy-engine-example/main.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "semantic_governance_policy_engine" {
+  source  = "GoogleCloudPlatform/vertex-ai/google//modules/semantic-governance-policy-engine"
+  version = "~> 7.3"
+
+  project_id = var.project_id
+  region     = var.region
+}

--- a/examples/semantic-governance-policy-engine-example/main.tf
+++ b/examples/semantic-governance-policy-engine-example/main.tf
@@ -15,8 +15,7 @@
  */
 
 module "semantic_governance_policy_engine" {
-  source  = "GoogleCloudPlatform/vertex-ai/google//modules/semantic-governance-policy-engine"
-  version = "~> 7.3"
+  source = "GoogleCloudPlatform/vertex-ai/google//modules/semantic-governance-policy-engine"
 
   project_id = var.project_id
   region     = var.region

--- a/examples/semantic-governance-policy-engine-example/outputs.tf
+++ b/examples/semantic-governance-policy-engine-example/outputs.tf
@@ -20,16 +20,16 @@ output "project_id" {
 }
 
 output "id" {
-  value       = module.semantic_governance_policy_engine.id
+  value       = module.semantic_governance_policy_engine.policy_engine.id
   description = "The engine identifier"
 }
 
 output "state" {
-  value       = module.semantic_governance_policy_engine.state
+  value       = module.semantic_governance_policy_engine.policy_engine.state
   description = "The current state of the engine"
 }
 
 output "psc_service_attachment" {
-  value       = module.semantic_governance_policy_engine.psc_service_attachment
+  value       = module.semantic_governance_policy_engine.policy_engine.psc_service_attachment
   description = "The Private Service Connect service attachment URI for the engine's managed endpoint"
 }

--- a/examples/semantic-governance-policy-engine-example/outputs.tf
+++ b/examples/semantic-governance-policy-engine-example/outputs.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value       = var.project_id
+  description = "The project ID"
+}
+
+output "id" {
+  value       = module.semantic_governance_policy_engine.id
+  description = "The engine identifier"
+}
+
+output "state" {
+  value       = module.semantic_governance_policy_engine.state
+  description = "The current state of the engine"
+}
+
+output "psc_service_attachment" {
+  value       = module.semantic_governance_policy_engine.psc_service_attachment
+  description = "The Private Service Connect service attachment URI for the engine's managed endpoint"
+}

--- a/examples/semantic-governance-policy-engine-example/variables.tf
+++ b/examples/semantic-governance-policy-engine-example/variables.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which the resource belongs"
+  type        = string
+}
+
+variable "region" {
+  description = "The region in which to provision the Semantic Governance Policy Engine"
+  type        = string
+  default     = "us-central1"
+}

--- a/modules/semantic-governance-policy-engine/README.md
+++ b/modules/semantic-governance-policy-engine/README.md
@@ -1,0 +1,74 @@
+# Vertex AI (Gemini Enterprise Agent Platform) Semantic Governance Policy Engine Module
+
+This module wraps the [`google_vertex_ai_semantic_governance_policy_engine`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_semantic_governance_policy_engine) resource. A Semantic Governance Policy Engine (SGPE) is the managed, runtime evaluation infrastructure for Semantic Governance Policies (SGP): the natural-language constraints that govern an AI agent's tool calls. You can find example(s) for this module [here](https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai/tree/main/examples/semantic-governance-policy-engine-example)
+
+The engine is a project-level, regional singleton — each project has at most one engine per region. Provisioning sets up managed Private Service Connect (PSC) networking in your VPC and a policy decision point that the Agent Gateway consults at runtime. The policies themselves and the Agent Gateway integration are configured separately and are not managed by this module.
+
+```hcl
+module "semantic_governance_policy_engine" {
+  source  = "GoogleCloudPlatform/vertex-ai/google//modules/semantic-governance-policy-engine"
+  version = "~> 7.3"
+
+  project_id = var.project_id
+  region     = "us-central1"
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| deletion\_policy | How Terraform treats destruction of the engine. One of DELETE (default; deprovision the engine), PREVENT (fail the destroy), or ABANDON (drop from state without deprovisioning). | `string` | `"DELETE"` | no |
+| project\_id | The ID of the project in which the resource belongs. If null, the provider project is used. | `string` | `null` | no |
+| region | The region of the SemanticGovernancePolicyEngine, e.g. 'us-central1'. Required by this module, even though the underlying resource treats region as optional. | `string` | n/a | yes |
+| timeout\_create | Timeout for creating (provisioning) the SemanticGovernancePolicyEngine. | `string` | `"60m"` | no |
+| timeout\_delete | Timeout for deleting (deprovisioning) the SemanticGovernancePolicyEngine. | `string` | `"60m"` | no |
+| timeout\_update | Timeout for updating the SemanticGovernancePolicyEngine. | `string` | `"60m"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| create\_time | The time the engine was created, in RFC3339 UTC 'Zulu' format. |
+| id | An identifier for the engine, in the form 'projects/{{project}}/locations/{{region}}/semanticGovernancePolicyEngine'. |
+| name | The resource name of the engine, in the form 'projects/{project}/locations/{region}/semanticGovernancePolicyEngine'. |
+| policy\_engine | The full google\_vertex\_ai\_semantic\_governance\_policy\_engine resource object. |
+| psc\_service\_attachment | The Private Service Connect service attachment URI for the engine's managed endpoint. Self-managed consumers target this to build their own PSC forwarding rule. |
+| state | The current state of the engine. One of STATE\_UNSPECIFIED, PROVISIONING, ACTIVE, FAILED, DEPROVISIONING, INACTIVE. |
+| update\_time | The time the engine was last updated, in RFC3339 UTC 'Zulu' format. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Notes
+
+- **`region` is required by this module**, even though the underlying resource treats it as optional.
+- **Provisioning and deprovisioning are long-running.** A `terraform apply` that creates the engine kicks off a provisioning LRO (typically a few minutes, up to ~20). Destroying it is also asynchronous. The `timeout_*` variables (each defaulting to `60m`) bound these operations.
+- **`psc_service_attachment` is the output most consumers need.** Self-managed customers target it to build their own PSC forwarding rule into the engine's managed endpoint.
+- Reading an uninitialized or deprovisioned engine returns the singleton with state `INACTIVE` rather than reporting it as absent.
+
+## Requirements
+
+These sections describe requirements for using this module.
+
+### Software
+
+The following dependencies must be available:
+
+- [Terraform][terraform] v1.3+
+- [Terraform Provider for GCP][terraform-provider-gcp] plugin v7.41+
+
+### Enable APIs
+
+The following API must be enabled on the project where the engine is provisioned:
+
+- `aiplatform.googleapis.com`
+
+### Service Account
+
+A service account (or user) with the following role must be used to provision the resources of this module:
+
+- Vertex AI Administrator: `roles/aiplatform.admin`
+
+[terraform]: https://www.terraform.io/downloads.html
+[terraform-provider-gcp]: https://registry.terraform.io/providers/hashicorp/google/latest

--- a/modules/semantic-governance-policy-engine/README.md
+++ b/modules/semantic-governance-policy-engine/README.md
@@ -20,23 +20,14 @@ module "semantic_governance_policy_engine" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | deletion\_policy | How Terraform treats destruction of the engine. One of DELETE (default; deprovision the engine), PREVENT (fail the destroy), or ABANDON (drop from state without deprovisioning). | `string` | `"DELETE"` | no |
-| project\_id | The ID of the project in which the resource belongs. If null, the provider project is used. | `string` | `null` | no |
+| project\_id | The ID of the project in which to create the SemanticGovernancePolicyEngine. | `string` | n/a | yes |
 | region | The region of the SemanticGovernancePolicyEngine, e.g. 'us-central1'. Required by this module, even though the underlying resource treats region as optional. | `string` | n/a | yes |
-| timeout\_create | Timeout for creating (provisioning) the SemanticGovernancePolicyEngine. | `string` | `"60m"` | no |
-| timeout\_delete | Timeout for deleting (deprovisioning) the SemanticGovernancePolicyEngine. | `string` | `"60m"` | no |
-| timeout\_update | Timeout for updating the SemanticGovernancePolicyEngine. | `string` | `"60m"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| create\_time | The time the engine was created, in RFC3339 UTC 'Zulu' format. |
-| id | An identifier for the engine, in the form 'projects/{{project}}/locations/{{region}}/semanticGovernancePolicyEngine'. |
-| name | The resource name of the engine, in the form 'projects/{project}/locations/{region}/semanticGovernancePolicyEngine'. |
 | policy\_engine | The full google\_vertex\_ai\_semantic\_governance\_policy\_engine resource object. |
-| psc\_service\_attachment | The Private Service Connect service attachment URI for the engine's managed endpoint. Self-managed consumers target this to build their own PSC forwarding rule. |
-| state | The current state of the engine. One of STATE\_UNSPECIFIED, PROVISIONING, ACTIVE, FAILED, DEPROVISIONING, INACTIVE. |
-| update\_time | The time the engine was last updated, in RFC3339 UTC 'Zulu' format. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/semantic-governance-policy-engine/main.tf
+++ b/modules/semantic-governance-policy-engine/main.tf
@@ -18,10 +18,4 @@ resource "google_vertex_ai_semantic_governance_policy_engine" "policy_engine" {
   region          = var.region
   project         = var.project_id
   deletion_policy = var.deletion_policy
-
-  timeouts {
-    create = var.timeout_create
-    update = var.timeout_update
-    delete = var.timeout_delete
-  }
 }

--- a/modules/semantic-governance-policy-engine/main.tf
+++ b/modules/semantic-governance-policy-engine/main.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_vertex_ai_semantic_governance_policy_engine" "policy_engine" {
+  region          = var.region
+  project         = var.project_id
+  deletion_policy = var.deletion_policy
+
+  timeouts {
+    create = var.timeout_create
+    update = var.timeout_update
+    delete = var.timeout_delete
+  }
+}

--- a/modules/semantic-governance-policy-engine/metadata.display.yaml
+++ b/modules/semantic-governance-policy-engine/metadata.display.yaml
@@ -1,0 +1,48 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-vertex-ai-semantic-governance-policy-engine-display
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Vertex AI (Gemini Enterprise Agent Platform) Semantic Governance Policy Engine Module
+    source:
+      repo: https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai.git
+      sourceType: git
+      dir: /modules/semantic-governance-policy-engine
+  ui:
+    input:
+      variables:
+        deletion_policy:
+          name: deletion_policy
+          title: Deletion Policy
+        project_id:
+          name: project_id
+          title: Project Id
+        region:
+          name: region
+          title: Region
+        timeout_create:
+          name: timeout_create
+          title: Timeout Create
+        timeout_delete:
+          name: timeout_delete
+          title: Timeout Delete
+        timeout_update:
+          name: timeout_update
+          title: Timeout Update

--- a/modules/semantic-governance-policy-engine/metadata.yaml
+++ b/modules/semantic-governance-policy-engine/metadata.yaml
@@ -15,32 +15,22 @@
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
-  name: terraform-google-vertex-ai
+  name: terraform-google-vertex-ai-semantic-governance-policy-engine
   annotations:
     config.kubernetes.io/local-config: "true"
 spec:
   info:
-    title: Google Module for Vertex AI resources
+    title: Vertex AI (Gemini Enterprise Agent Platform) Semantic Governance Policy Engine Module
     source:
       repo: https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai.git
       sourceType: git
+      dir: /modules/semantic-governance-policy-engine
+    version: 7.3.1
+    actuationTool:
+      flavor: Terraform
+      version: ">= 1.3"
     description: {}
   content:
-    subBlueprints:
-      - name: agent-engine
-        location: modules/agent-engine
-      - name: agent-engine-nightly
-        location: modules/agent-engine-nightly
-      - name: feature-online-store
-        location: modules/feature-online-store
-      - name: model-armor-floorsetting
-        location: modules/model-armor-floorsetting
-      - name: model-armor-template
-        location: modules/model-armor-template
-      - name: semantic-governance-policy-engine
-        location: modules/semantic-governance-policy-engine
-      - name: workbench
-        location: modules/workbench
     examples:
       - name: agent-engine-developer-connect-example
         location: examples/agent-engine-developer-connect-example
@@ -60,7 +50,46 @@ spec:
         location: examples/workbench-complete-example
       - name: workbench-simple-example
         location: examples/workbench-simple-example
-  interfaces: {}
+  interfaces:
+    variables:
+      - name: region
+        description: The region of the SemanticGovernancePolicyEngine, e.g. 'us-central1'. Required by this module, even though the underlying resource treats region as optional.
+        varType: string
+        required: true
+      - name: project_id
+        description: The ID of the project in which the resource belongs. If null, the provider project is used.
+        varType: string
+      - name: deletion_policy
+        description: How Terraform treats destruction of the engine. One of DELETE (default; deprovision the engine), PREVENT (fail the destroy), or ABANDON (drop from state without deprovisioning).
+        varType: string
+        defaultValue: DELETE
+      - name: timeout_create
+        description: Timeout for creating (provisioning) the SemanticGovernancePolicyEngine.
+        varType: string
+        defaultValue: 60m
+      - name: timeout_update
+        description: Timeout for updating the SemanticGovernancePolicyEngine.
+        varType: string
+        defaultValue: 60m
+      - name: timeout_delete
+        description: Timeout for deleting (deprovisioning) the SemanticGovernancePolicyEngine.
+        varType: string
+        defaultValue: 60m
+    outputs:
+      - name: create_time
+        description: The time the engine was created, in RFC3339 UTC 'Zulu' format.
+      - name: id
+        description: An identifier for the engine, in the form 'projects/{{project}}/locations/{{region}}/semanticGovernancePolicyEngine'.
+      - name: name
+        description: The resource name of the engine, in the form 'projects/{project}/locations/{region}/semanticGovernancePolicyEngine'.
+      - name: policy_engine
+        description: The full google_vertex_ai_semantic_governance_policy_engine resource object.
+      - name: psc_service_attachment
+        description: The Private Service Connect service attachment URI for the engine's managed endpoint. Self-managed consumers target this to build their own PSC forwarding rule.
+      - name: state
+        description: The current state of the engine. One of STATE_UNSPECIFIED, PROVISIONING, ACTIVE, FAILED, DEPROVISIONING, INACTIVE.
+      - name: update_time
+        description: The time the engine was last updated, in RFC3339 UTC 'Zulu' format.
   requirements:
     roles:
       - level: Project
@@ -92,3 +121,6 @@ spec:
       - iap.googleapis.com
       - modelarmor.googleapis.com
       - dlp.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 7.41.0, < 8"

--- a/modules/semantic-governance-policy-engine/metadata.yaml
+++ b/modules/semantic-governance-policy-engine/metadata.yaml
@@ -57,39 +57,16 @@ spec:
         varType: string
         required: true
       - name: project_id
-        description: The ID of the project in which the resource belongs. If null, the provider project is used.
+        description: The ID of the project in which to create the SemanticGovernancePolicyEngine.
         varType: string
+        required: true
       - name: deletion_policy
         description: How Terraform treats destruction of the engine. One of DELETE (default; deprovision the engine), PREVENT (fail the destroy), or ABANDON (drop from state without deprovisioning).
         varType: string
         defaultValue: DELETE
-      - name: timeout_create
-        description: Timeout for creating (provisioning) the SemanticGovernancePolicyEngine.
-        varType: string
-        defaultValue: 60m
-      - name: timeout_update
-        description: Timeout for updating the SemanticGovernancePolicyEngine.
-        varType: string
-        defaultValue: 60m
-      - name: timeout_delete
-        description: Timeout for deleting (deprovisioning) the SemanticGovernancePolicyEngine.
-        varType: string
-        defaultValue: 60m
     outputs:
-      - name: create_time
-        description: The time the engine was created, in RFC3339 UTC 'Zulu' format.
-      - name: id
-        description: An identifier for the engine, in the form 'projects/{{project}}/locations/{{region}}/semanticGovernancePolicyEngine'.
-      - name: name
-        description: The resource name of the engine, in the form 'projects/{project}/locations/{region}/semanticGovernancePolicyEngine'.
       - name: policy_engine
         description: The full google_vertex_ai_semantic_governance_policy_engine resource object.
-      - name: psc_service_attachment
-        description: The Private Service Connect service attachment URI for the engine's managed endpoint. Self-managed consumers target this to build their own PSC forwarding rule.
-      - name: state
-        description: The current state of the engine. One of STATE_UNSPECIFIED, PROVISIONING, ACTIVE, FAILED, DEPROVISIONING, INACTIVE.
-      - name: update_time
-        description: The time the engine was last updated, in RFC3339 UTC 'Zulu' format.
   requirements:
     roles:
       - level: Project

--- a/modules/semantic-governance-policy-engine/outputs.tf
+++ b/modules/semantic-governance-policy-engine/outputs.tf
@@ -18,33 +18,3 @@ output "policy_engine" {
   description = "The full google_vertex_ai_semantic_governance_policy_engine resource object."
   value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine
 }
-
-output "id" {
-  description = "An identifier for the engine, in the form 'projects/{{project}}/locations/{{region}}/semanticGovernancePolicyEngine'."
-  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.id
-}
-
-output "name" {
-  description = "The resource name of the engine, in the form 'projects/{project}/locations/{region}/semanticGovernancePolicyEngine'."
-  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.name
-}
-
-output "state" {
-  description = "The current state of the engine. One of STATE_UNSPECIFIED, PROVISIONING, ACTIVE, FAILED, DEPROVISIONING, INACTIVE."
-  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.state
-}
-
-output "psc_service_attachment" {
-  description = "The Private Service Connect service attachment URI for the engine's managed endpoint. Self-managed consumers target this to build their own PSC forwarding rule."
-  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.psc_service_attachment
-}
-
-output "create_time" {
-  description = "The time the engine was created, in RFC3339 UTC 'Zulu' format."
-  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.create_time
-}
-
-output "update_time" {
-  description = "The time the engine was last updated, in RFC3339 UTC 'Zulu' format."
-  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.update_time
-}

--- a/modules/semantic-governance-policy-engine/outputs.tf
+++ b/modules/semantic-governance-policy-engine/outputs.tf
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "policy_engine" {
+  description = "The full google_vertex_ai_semantic_governance_policy_engine resource object."
+  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine
+}
+
+output "id" {
+  description = "An identifier for the engine, in the form 'projects/{{project}}/locations/{{region}}/semanticGovernancePolicyEngine'."
+  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.id
+}
+
+output "name" {
+  description = "The resource name of the engine, in the form 'projects/{project}/locations/{region}/semanticGovernancePolicyEngine'."
+  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.name
+}
+
+output "state" {
+  description = "The current state of the engine. One of STATE_UNSPECIFIED, PROVISIONING, ACTIVE, FAILED, DEPROVISIONING, INACTIVE."
+  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.state
+}
+
+output "psc_service_attachment" {
+  description = "The Private Service Connect service attachment URI for the engine's managed endpoint. Self-managed consumers target this to build their own PSC forwarding rule."
+  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.psc_service_attachment
+}
+
+output "create_time" {
+  description = "The time the engine was created, in RFC3339 UTC 'Zulu' format."
+  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.create_time
+}
+
+output "update_time" {
+  description = "The time the engine was last updated, in RFC3339 UTC 'Zulu' format."
+  value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine.update_time
+}

--- a/modules/semantic-governance-policy-engine/variables.tf
+++ b/modules/semantic-governance-policy-engine/variables.tf
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "region" {
+  description = "The region of the SemanticGovernancePolicyEngine, e.g. 'us-central1'. Required by this module, even though the underlying resource treats region as optional."
+  type        = string
+}
+
+variable "project_id" {
+  description = "The ID of the project in which the resource belongs. If null, the provider project is used."
+  type        = string
+  default     = null
+}
+
+variable "deletion_policy" {
+  description = "How Terraform treats destruction of the engine. One of DELETE (default; deprovision the engine), PREVENT (fail the destroy), or ABANDON (drop from state without deprovisioning)."
+  type        = string
+  default     = "DELETE"
+  validation {
+    condition     = contains(["DELETE", "PREVENT", "ABANDON"], var.deletion_policy)
+    error_message = "deletion_policy must be one of DELETE, PREVENT, or ABANDON."
+  }
+}
+
+variable "timeout_create" {
+  description = "Timeout for creating (provisioning) the SemanticGovernancePolicyEngine."
+  type        = string
+  default     = "60m"
+}
+
+variable "timeout_update" {
+  description = "Timeout for updating the SemanticGovernancePolicyEngine."
+  type        = string
+  default     = "60m"
+}
+
+variable "timeout_delete" {
+  description = "Timeout for deleting (deprovisioning) the SemanticGovernancePolicyEngine."
+  type        = string
+  default     = "60m"
+}

--- a/modules/semantic-governance-policy-engine/variables.tf
+++ b/modules/semantic-governance-policy-engine/variables.tf
@@ -20,9 +20,8 @@ variable "region" {
 }
 
 variable "project_id" {
-  description = "The ID of the project in which the resource belongs. If null, the provider project is used."
+  description = "The ID of the project in which to create the SemanticGovernancePolicyEngine."
   type        = string
-  default     = null
 }
 
 variable "deletion_policy" {
@@ -33,22 +32,4 @@ variable "deletion_policy" {
     condition     = contains(["DELETE", "PREVENT", "ABANDON"], var.deletion_policy)
     error_message = "deletion_policy must be one of DELETE, PREVENT, or ABANDON."
   }
-}
-
-variable "timeout_create" {
-  description = "Timeout for creating (provisioning) the SemanticGovernancePolicyEngine."
-  type        = string
-  default     = "60m"
-}
-
-variable "timeout_update" {
-  description = "Timeout for updating the SemanticGovernancePolicyEngine."
-  type        = string
-  default     = "60m"
-}
-
-variable "timeout_delete" {
-  description = "Timeout for deleting (deprovisioning) the SemanticGovernancePolicyEngine."
-  type        = string
-  default     = "60m"
 }

--- a/modules/semantic-governance-policy-engine/versions.tf
+++ b/modules/semantic-governance-policy-engine/versions.tf
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.41.0, < 8"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vertex-ai:semantic-governance-policy-engine/v7.3.1"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `semantic-governance-policy-engine` sub-module wrapping the `google_vertex_ai_semantic_governance_policy_engine` resource (GA in `hashicorp/google` 7.41.0), plus a matching example and the standard README / metadata / root wiring.

A Semantic Governance Policy Engine (SGPE) is the managed runtime that evaluates Semantic Governance Policies — the natural-language constraints governing an AI agent's tool calls. It is a project-regional singleton; provisioning stands up managed Private Service Connect networking and a policy decision point.

## Design notes

- `region` is required by the module, even though the resource treats it as optional.
- `deletion_policy` is validated (`DELETE`/`PREVENT`/`ABANDON`).
- No apply-based integration test in this initial PR; the example is plan-tested via auto-discovery, and the resource is already apply-tested in the `hashicorp/google` provider.

## Testing

- `terraform fmt`, `init`, `validate`, `plan` clean on the module and example.
- Repo lint (`test_lint.sh`) passes locally: file headers, doc generation, tflint, fmt, validate.