### PR TITLE
feat!: add gateway_configs support to semantic-governance-policy-engine

### DIFF
--- a/examples/semantic-governance-policy-engine-example/README.md
+++ b/examples/semantic-governance-policy-engine-example/README.md
@@ -18,6 +18,17 @@ terraform plan
 terraform apply
 ```
 
+### Attaching customer-VPC PSC gateways
+
+This example provisions the engine with no gateways. To expose it over Private
+Service Connect endpoints in your own VPC, set the `gateway_configs` input (a map
+keyed by gateway name, at most 5). It is left out of this minimal example because
+each gateway provisions real PSC networking and a DNS A-record.
+
+For a complete, runnable configuration — including the network, subnetwork, and
+private DNS zone a gateway requires — see the
+[gateway example](../semantic-governance-policy-engine-gateway-example).
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/semantic-governance-policy-engine-gateway-example/README.md
+++ b/examples/semantic-governance-policy-engine-gateway-example/README.md
@@ -4,7 +4,7 @@ This example provisions a [Semantic Governance Policy Engine](https://cloud.goog
 
 Unlike the [minimal example](../semantic-governance-policy-engine-example), which provisions the engine with no gateways, this one also creates the networking a gateway needs — a VPC network, a subnetwork, and a private Cloud DNS zone — and references them from a `gateway_configs` entry. The engine creates a consumer-side PSC endpoint and publishes an A-record for the gateway into the private zone.
 
-Each gateway entry must set `network`, `subnetwork`, and `dns_zone_name` together; the engine rejects a partial set. The network and subnetwork are passed as their full resource URIs — the resources' `.id` (of the form `projects/P/global/networks/N`), not `.self_link` (the `https://` form the API rejects) — so the configuration matches what the API stores and the gateway does not churn on later plans.
+Within a gateway entry, `network`, `subnetwork`, and `dns_zone_name` must be set together or all omitted; a partial set is rejected — this example sets all three. Network and subnetwork are passed as their full resource URIs — the resources' `.id` (of the form `projects/P/global/networks/N`), not `.self_link` (the `https://` form the API rejects) — so the configuration matches what the API stores and the gateway does not churn on later plans.
 
 > **Note:** provisioning the engine and each gateway is a long-running operation (typically a few minutes, up to ~20), and it creates real PSC/DNS infrastructure. This example is provided as a reference for using `gateway_configs`; it is not part of the module's automated integration test suite.
 
@@ -40,6 +40,6 @@ terraform apply
 
 | Name | Description |
 |------|-------------|
-| gateway\_endpoints | Map of gateway name to its full gateway object (inputs plus computed dns\_record, ip\_address, psc\_endpoint, state). |
+| gateway\_endpoints | List of gateway objects (each with inputs plus computed dns\_record, ip\_address, psc\_endpoint, state). |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/semantic-governance-policy-engine-gateway-example/README.md
+++ b/examples/semantic-governance-policy-engine-gateway-example/README.md
@@ -1,0 +1,45 @@
+# Semantic Governance Policy Engine with a PSC gateway example
+
+This example provisions a [Semantic Governance Policy Engine](https://cloud.google.com/gemini-enterprise-agent-platform/govern/policies/semantic-governance-overview) and attaches one customer-VPC Private Service Connect (PSC) gateway to it via the module's `gateway_configs` input.
+
+Unlike the [minimal example](../semantic-governance-policy-engine-example), which provisions the engine with no gateways, this one also creates the networking a gateway needs — a VPC network, a subnetwork, and a private Cloud DNS zone — and references them from a `gateway_configs` entry. The engine creates a consumer-side PSC endpoint and publishes an A-record for the gateway into the private zone.
+
+Each gateway entry must set `network`, `subnetwork`, and `dns_zone_name` together; the engine rejects a partial set. The network and subnetwork are passed as their full resource URIs — the resources' `.id` (of the form `projects/P/global/networks/N`), not `.self_link` (the `https://` form the API rejects) — so the configuration matches what the API stores and the gateway does not churn on later plans.
+
+> **Note:** provisioning the engine and each gateway is a long-running operation (typically a few minutes, up to ~20), and it creates real PSC/DNS infrastructure. This example is provided as a reference for using `gateway_configs`; it is not part of the module's automated integration test suite.
+
+## Usage
+
+To run this example execute:
+
+```bash
+export TF_VAR_project_id="your_project_id"
+```
+
+```tf
+terraform init
+terraform plan
+terraform apply
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dns\_name | DNS suffix for the private managed zone (must be a fully-qualified name ending in a dot). | `string` | `"internal.sgp.local."` | no |
+| dns\_zone\_name | Name of the private Cloud DNS managed zone the engine publishes the gateway's A-record into. | `string` | `"sgp-private-zone"` | no |
+| gateway\_name | Name of the PSC gateway (used as the key in the engine's gateway\_configs map). | `string` | `"agent-gateway"` | no |
+| network\_name | Name of the VPC network the PSC gateway attaches to. | `string` | `"agent-network"` | no |
+| project\_id | The ID of the project in which the resources belong. | `string` | n/a | yes |
+| region | The region in which to provision the engine and the gateway's subnetwork. | `string` | `"us-central1"` | no |
+| subnetwork\_cidr | Primary IPv4 CIDR range for the subnetwork. | `string` | `"10.0.0.0/24"` | no |
+| subnetwork\_name | Name of the subnetwork the PSC gateway attaches to. | `string` | `"agent-subnet"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| gateway\_endpoints | Map of gateway name to its full gateway object (inputs plus computed dns\_record, ip\_address, psc\_endpoint, state). |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/semantic-governance-policy-engine-gateway-example/main.tf
+++ b/examples/semantic-governance-policy-engine-gateway-example/main.tf
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Customer-VPC networking that the PSC gateway attaches to. A gateway_configs
+# entry must reference an existing network, subnetwork, and private DNS zone
+# together (the engine rejects a partial set), so this example creates all three.
+
+resource "google_compute_network" "agent_network" {
+  project                 = var.project_id
+  name                    = var.network_name
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "agent_subnet" {
+  project       = var.project_id
+  name          = var.subnetwork_name
+  region        = var.region
+  network       = google_compute_network.agent_network.id
+  ip_cidr_range = var.subnetwork_cidr
+}
+
+# Private zone into which the engine publishes the gateway's A-record.
+resource "google_dns_managed_zone" "sgp_private_zone" {
+  project     = var.project_id
+  name        = var.dns_zone_name
+  dns_name    = var.dns_name
+  description = "Private zone for Semantic Governance Policy Engine gateway A-records."
+  visibility  = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = google_compute_network.agent_network.id
+    }
+  }
+}
+
+module "semantic_governance_policy_engine" {
+  source = "GoogleCloudPlatform/vertex-ai/google//modules/semantic-governance-policy-engine"
+
+  project_id = var.project_id
+  region     = var.region
+
+  # One customer-VPC PSC gateway. network/subnetwork are passed as their full
+  # resource URIs (the resources' .id, e.g. projects/P/global/networks/N -- not
+  # .self_link, which is the https:// form the API rejects) so the config matches
+  # what the API stores and the gateway does not churn on subsequent plans.
+  gateway_configs = {
+    (var.gateway_name) = {
+      network       = google_compute_network.agent_network.id
+      subnetwork    = google_compute_subnetwork.agent_subnet.id
+      dns_zone_name = google_dns_managed_zone.sgp_private_zone.name
+    }
+  }
+}

--- a/examples/semantic-governance-policy-engine-gateway-example/outputs.tf
+++ b/examples/semantic-governance-policy-engine-gateway-example/outputs.tf
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-# Surface the module's by-name gateway_endpoints output. To read one field:
-# module...gateway_endpoints["agent-gateway"].dns_record
+# Surface the module's gateway_endpoints list. To read one gateway's field:
+# module...gateway_endpoints[0].dns_record
 output "gateway_endpoints" {
   value       = module.semantic_governance_policy_engine.gateway_endpoints
-  description = "Map of gateway name to its full gateway object (inputs plus computed dns_record, ip_address, psc_endpoint, state)."
+  description = "List of gateway objects (each with inputs plus computed dns_record, ip_address, psc_endpoint, state)."
 }

--- a/examples/semantic-governance-policy-engine-gateway-example/outputs.tf
+++ b/examples/semantic-governance-policy-engine-gateway-example/outputs.tf
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
-resource "google_vertex_ai_semantic_governance_policy_engine" "policy_engine" {
-  region          = var.region
-  project         = var.project_id
-  deletion_policy = var.deletion_policy
-
-  dynamic "gateway_configs" {
-    for_each = var.gateway_configs
-    content {
-      name             = gateway_configs.key
-      network          = gateway_configs.value.network
-      subnetwork       = gateway_configs.value.subnetwork
-      dns_zone_name    = gateway_configs.value.dns_zone_name
-      allowed_projects = gateway_configs.value.allowed_projects
-    }
-  }
+# Surface the module's by-name gateway_endpoints output. To read one field:
+# module...gateway_endpoints["agent-gateway"].dns_record
+output "gateway_endpoints" {
+  value       = module.semantic_governance_policy_engine.gateway_endpoints
+  description = "Map of gateway name to its full gateway object (inputs plus computed dns_record, ip_address, psc_endpoint, state)."
 }

--- a/examples/semantic-governance-policy-engine-gateway-example/variables.tf
+++ b/examples/semantic-governance-policy-engine-gateway-example/variables.tf
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which the resources belong."
+  type        = string
+}
+
+variable "region" {
+  description = "The region in which to provision the engine and the gateway's subnetwork."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "network_name" {
+  description = "Name of the VPC network the PSC gateway attaches to."
+  type        = string
+  default     = "agent-network"
+}
+
+variable "subnetwork_name" {
+  description = "Name of the subnetwork the PSC gateway attaches to."
+  type        = string
+  default     = "agent-subnet"
+}
+
+variable "subnetwork_cidr" {
+  description = "Primary IPv4 CIDR range for the subnetwork."
+  type        = string
+  default     = "10.0.0.0/24"
+}
+
+variable "dns_zone_name" {
+  description = "Name of the private Cloud DNS managed zone the engine publishes the gateway's A-record into."
+  type        = string
+  default     = "sgp-private-zone"
+}
+
+variable "dns_name" {
+  description = "DNS suffix for the private managed zone (must be a fully-qualified name ending in a dot)."
+  type        = string
+  default     = "internal.sgp.local."
+}
+
+variable "gateway_name" {
+  description = "Name of the PSC gateway (used as the key in the engine's gateway_configs map)."
+  type        = string
+  default     = "agent-gateway"
+}

--- a/modules/semantic-governance-policy-engine/README.md
+++ b/modules/semantic-governance-policy-engine/README.md
@@ -1,6 +1,6 @@
 # Vertex AI (Gemini Enterprise Agent Platform) Semantic Governance Policy Engine Module
 
-This module wraps the [`google_vertex_ai_semantic_governance_policy_engine`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_semantic_governance_policy_engine) resource. A Semantic Governance Policy Engine (SGPE) is the managed, runtime evaluation infrastructure for Semantic Governance Policies (SGP): the natural-language constraints that govern an AI agent's tool calls. You can find example(s) for this module [here](https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai/tree/main/examples/semantic-governance-policy-engine-example)
+This module wraps the [`google_vertex_ai_semantic_governance_policy_engine`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_semantic_governance_policy_engine) resource. A Semantic Governance Policy Engine (SGPE) is the managed, runtime evaluation infrastructure for Semantic Governance Policies (SGP): the natural-language constraints that govern an AI agent's tool calls. You can find examples for this module here: the [minimal example](https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai/tree/main/examples/semantic-governance-policy-engine-example) and the [gateway example](https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai/tree/main/examples/semantic-governance-policy-engine-gateway-example)
 
 The engine is a project-level, regional singleton — each project has at most one engine per region. Provisioning sets up managed Private Service Connect (PSC) networking in your VPC and a policy decision point that the Agent Gateway consults at runtime. The policies themselves and the Agent Gateway integration are configured separately and are not managed by this module.
 
@@ -20,7 +20,7 @@ module "semantic_governance_policy_engine" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | deletion\_policy | How Terraform treats destruction of the engine. One of DELETE (default; deprovision the engine), PREVENT (fail the destroy), or ABANDON (drop from state without deprovisioning). | `string` | `"DELETE"` | no |
-| gateway\_configs | Customer-VPC PSC gateway configurations, keyed by gateway name (at most 5). Each entry provisions a Private Service Connect endpoint. Within an entry, network, subnetwork, and dns\_zone\_name must all be set together or all omitted (a partial set is rejected); when set, network and subnetwork are full resource URIs and dns\_zone\_name is the private Cloud DNS zone the gateway's A-record is published into. allowed\_projects (optional) enables decoupled mode and takes full 'projects/{id}' resource names. | <pre>map(object({<br>    network          = optional(string)<br>    subnetwork       = optional(string)<br>    dns_zone_name    = optional(string)<br>    allowed_projects = optional(list(string))<br>  }))</pre> | `{}` | no |
+| gateway\_configs | Customer-VPC PSC gateway configurations, keyed by gateway name (at most 5). Each entry provisions a Private Service Connect endpoint. Within an entry, network, subnetwork, and dns\_zone\_name must all be set together or all omitted (a partial set is rejected); when set, network and subnetwork are the resources' .id (not .self\_link, which the API rejects) and dns\_zone\_name is the private Cloud DNS zone the gateway's A-record is published into. allowed\_projects (optional) takes full 'projects/{id}' resource names. | <pre>map(object({<br>    network          = optional(string)<br>    subnetwork       = optional(string)<br>    dns_zone_name    = optional(string)<br>    allowed_projects = optional(list(string))<br>  }))</pre> | `{}` | no |
 | project\_id | The ID of the project in which to create the SemanticGovernancePolicyEngine. | `string` | n/a | yes |
 | region | The region of the SemanticGovernancePolicyEngine, e.g. 'us-central1'. Required by this module, even though the underlying resource treats region as optional. | `string` | n/a | yes |
 
@@ -28,7 +28,7 @@ module "semantic_governance_policy_engine" {
 
 | Name | Description |
 |------|-------------|
-| gateway\_endpoints | Map of gateway name to its full gateway object (the inputs plus the computed fields dns\_record, ip\_address, psc\_endpoint, state). |
+| gateway\_endpoints | List of gateway objects (each with the inputs plus the computed fields dns\_record, ip\_address, psc\_endpoint, state). |
 | policy\_engine | The full google\_vertex\_ai\_semantic\_governance\_policy\_engine resource object. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -37,9 +37,9 @@ module "semantic_governance_policy_engine" {
 
 - **`region` is required by this module**, even though the underlying resource treats it as optional.
 - **Provisioning and deprovisioning are long-running.** A `terraform apply` that creates the engine kicks off a provisioning LRO (typically a few minutes, up to ~20). Destroying it is also asynchronous. The underlying resource's operation timeouts (60 minutes) bound these operations.
-- **`psc_service_attachment` is the output most consumers need.** Self-managed customers target it to build their own PSC forwarding rule into the engine's managed endpoint.
+- **`policy_engine.psc_service_attachment` is the attribute most consumers need.** Self-managed customers target it to build their own PSC forwarding rule into the engine's managed endpoint.
 - Reading an uninitialized or deprovisioned engine returns the singleton with state `INACTIVE` rather than reporting it as absent.
-- **Reading per-gateway values.** The `gateway_endpoints` output is a map of gateway name to the full gateway object, so a caller reads one gateway's computed values by name — e.g. `module.<NAME>.gateway_endpoints["my-gateway"].dns_record` (also `ip_address`, `psc_endpoint`, `state`). The [gateway example](../../examples/semantic-governance-policy-engine-gateway-example) shows this in its `outputs.tf`. The `policy_engine` output carries the same per-gateway values inside `policy_engine.gateway_configs`, but as a **set** that cannot be indexed by gateway name.
+- **Reading per-gateway values.** The `gateway_endpoints` output is a list of the full gateway objects, so a caller reads one gateway's computed values by position — e.g. `module.<NAME>.gateway_endpoints[0].dns_record` (also `ip_address`, `psc_endpoint`, `state`). It is a list rather than a name-keyed map because Application Design Center connections select outputs by positional index; a Terraform consumer wanting by-name access can re-key it with `{ for g in module.<NAME>.gateway_endpoints : g.name => g }`. The [gateway example](../../examples/semantic-governance-policy-engine-gateway-example) shows the list output in its `outputs.tf`. The `policy_engine` output carries the same per-gateway values inside `policy_engine.gateway_configs`, but as a **set**, which cannot be indexed.
 
 ## Requirements
 

--- a/modules/semantic-governance-policy-engine/README.md
+++ b/modules/semantic-governance-policy-engine/README.md
@@ -20,6 +20,7 @@ module "semantic_governance_policy_engine" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | deletion\_policy | How Terraform treats destruction of the engine. One of DELETE (default; deprovision the engine), PREVENT (fail the destroy), or ABANDON (drop from state without deprovisioning). | `string` | `"DELETE"` | no |
+| gateway\_configs | Customer-VPC PSC gateway configurations, keyed by gateway name (at most 5). Each entry provisions a Private Service Connect endpoint. Within an entry, network, subnetwork, and dns\_zone\_name must all be set together or all omitted (a partial set is rejected); when set, network and subnetwork are full resource URIs and dns\_zone\_name is the private Cloud DNS zone the gateway's A-record is published into. allowed\_projects (optional) enables decoupled mode and takes full 'projects/{id}' resource names. | <pre>map(object({<br>    network          = optional(string)<br>    subnetwork       = optional(string)<br>    dns_zone_name    = optional(string)<br>    allowed_projects = optional(list(string))<br>  }))</pre> | `{}` | no |
 | project\_id | The ID of the project in which to create the SemanticGovernancePolicyEngine. | `string` | n/a | yes |
 | region | The region of the SemanticGovernancePolicyEngine, e.g. 'us-central1'. Required by this module, even though the underlying resource treats region as optional. | `string` | n/a | yes |
 
@@ -27,6 +28,7 @@ module "semantic_governance_policy_engine" {
 
 | Name | Description |
 |------|-------------|
+| gateway\_endpoints | Map of gateway name to its full gateway object (the inputs plus the computed fields dns\_record, ip\_address, psc\_endpoint, state). |
 | policy\_engine | The full google\_vertex\_ai\_semantic\_governance\_policy\_engine resource object. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -34,9 +36,10 @@ module "semantic_governance_policy_engine" {
 ## Notes
 
 - **`region` is required by this module**, even though the underlying resource treats it as optional.
-- **Provisioning and deprovisioning are long-running.** A `terraform apply` that creates the engine kicks off a provisioning LRO (typically a few minutes, up to ~20). Destroying it is also asynchronous. The `timeout_*` variables (each defaulting to `60m`) bound these operations.
+- **Provisioning and deprovisioning are long-running.** A `terraform apply` that creates the engine kicks off a provisioning LRO (typically a few minutes, up to ~20). Destroying it is also asynchronous. The underlying resource's operation timeouts (60 minutes) bound these operations.
 - **`psc_service_attachment` is the output most consumers need.** Self-managed customers target it to build their own PSC forwarding rule into the engine's managed endpoint.
 - Reading an uninitialized or deprovisioned engine returns the singleton with state `INACTIVE` rather than reporting it as absent.
+- **Reading per-gateway values.** The `gateway_endpoints` output is a map of gateway name to the full gateway object, so a caller reads one gateway's computed values by name — e.g. `module.<NAME>.gateway_endpoints["my-gateway"].dns_record` (also `ip_address`, `psc_endpoint`, `state`). The [gateway example](../../examples/semantic-governance-policy-engine-gateway-example) shows this in its `outputs.tf`. The `policy_engine` output carries the same per-gateway values inside `policy_engine.gateway_configs`, but as a **set** that cannot be indexed by gateway name.
 
 ## Requirements
 
@@ -47,7 +50,7 @@ These sections describe requirements for using this module.
 The following dependencies must be available:
 
 - [Terraform][terraform] v1.3+
-- [Terraform Provider for GCP][terraform-provider-gcp] plugin v7.41+
+- [Terraform Provider for GCP][terraform-provider-gcp] plugin v8.1+
 
 ### Enable APIs
 

--- a/modules/semantic-governance-policy-engine/metadata.display.yaml
+++ b/modules/semantic-governance-policy-engine/metadata.display.yaml
@@ -31,6 +31,9 @@ spec:
         deletion_policy:
           name: deletion_policy
           title: Deletion Policy
+        gateway_configs:
+          name: gateway_configs
+          title: Gateway Configs
         project_id:
           name: project_id
           title: Project Id

--- a/modules/semantic-governance-policy-engine/metadata.yaml
+++ b/modules/semantic-governance-policy-engine/metadata.yaml
@@ -67,7 +67,7 @@ spec:
         varType: string
         defaultValue: DELETE
       - name: gateway_configs
-        description: Customer-VPC PSC gateway configurations, keyed by gateway name (at most 5). Each entry provisions a Private Service Connect endpoint. Within an entry, network, subnetwork, and dns_zone_name must all be set together or all omitted (a partial set is rejected); when set, network and subnetwork are full resource URIs and dns_zone_name is the private Cloud DNS zone the gateway's A-record is published into. allowed_projects (optional) enables decoupled mode and takes full 'projects/{id}' resource names.
+        description: Customer-VPC PSC gateway configurations, keyed by gateway name (at most 5). Each entry provisions a Private Service Connect endpoint. Within an entry, network, subnetwork, and dns_zone_name must all be set together or all omitted (a partial set is rejected); when set, network and subnetwork are the resources' .id (not .self_link, which the API rejects) and dns_zone_name is the private Cloud DNS zone the gateway's A-record is published into. allowed_projects (optional) takes full 'projects/{id}' resource names.
         varType: |-
           map(object({
               network          = optional(string)
@@ -78,9 +78,9 @@ spec:
         defaultValue: {}
     outputs:
       - name: gateway_endpoints
-        description: Map of gateway name to its full gateway object (the inputs plus the computed fields dns_record, ip_address, psc_endpoint, state).
+        description: List of gateway objects (each with the inputs plus the computed fields dns_record, ip_address, psc_endpoint, state).
         type:
-          - map
+          - list
           - - object
             - allowed_projects:
                 - list
@@ -155,4 +155,4 @@ spec:
       - dlp.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 8.1.0, < 9"
+        version: ">= 8.1, < 9"

--- a/modules/semantic-governance-policy-engine/metadata.yaml
+++ b/modules/semantic-governance-policy-engine/metadata.yaml
@@ -79,8 +79,49 @@ spec:
     outputs:
       - name: gateway_endpoints
         description: Map of gateway name to its full gateway object (the inputs plus the computed fields dns_record, ip_address, psc_endpoint, state).
+        type:
+          - map
+          - - object
+            - allowed_projects:
+                - list
+                - string
+              dns_record: string
+              dns_zone_name: string
+              ip_address: string
+              name: string
+              network: string
+              psc_endpoint: string
+              state: string
+              subnetwork: string
       - name: policy_engine
         description: The full google_vertex_ai_semantic_governance_policy_engine resource object.
+        type:
+          - object
+          - create_time: string
+            deletion_policy: string
+            gateway_configs:
+              - set
+              - - object
+                - allowed_projects:
+                    - list
+                    - string
+                  dns_record: string
+                  dns_zone_name: string
+                  ip_address: string
+                  name: string
+                  network: string
+                  psc_endpoint: string
+                  state: string
+                  subnetwork: string
+            id: string
+            ip_address: string
+            name: string
+            project: string
+            psc_forwarding_rule: string
+            psc_service_attachment: string
+            region: string
+            state: string
+            update_time: string
   requirements:
     roles:
       - level: Project

--- a/modules/semantic-governance-policy-engine/metadata.yaml
+++ b/modules/semantic-governance-policy-engine/metadata.yaml
@@ -46,6 +46,8 @@ spec:
         location: examples/model-armor-template-example
       - name: semantic-governance-policy-engine-example
         location: examples/semantic-governance-policy-engine-example
+      - name: semantic-governance-policy-engine-gateway-example
+        location: examples/semantic-governance-policy-engine-gateway-example
       - name: workbench-complete-example
         location: examples/workbench-complete-example
       - name: workbench-simple-example
@@ -64,7 +66,19 @@ spec:
         description: How Terraform treats destruction of the engine. One of DELETE (default; deprovision the engine), PREVENT (fail the destroy), or ABANDON (drop from state without deprovisioning).
         varType: string
         defaultValue: DELETE
+      - name: gateway_configs
+        description: Customer-VPC PSC gateway configurations, keyed by gateway name (at most 5). Each entry provisions a Private Service Connect endpoint. Within an entry, network, subnetwork, and dns_zone_name must all be set together or all omitted (a partial set is rejected); when set, network and subnetwork are full resource URIs and dns_zone_name is the private Cloud DNS zone the gateway's A-record is published into. allowed_projects (optional) enables decoupled mode and takes full 'projects/{id}' resource names.
+        varType: |-
+          map(object({
+              network          = optional(string)
+              subnetwork       = optional(string)
+              dns_zone_name    = optional(string)
+              allowed_projects = optional(list(string))
+            }))
+        defaultValue: {}
     outputs:
+      - name: gateway_endpoints
+        description: Map of gateway name to its full gateway object (the inputs plus the computed fields dns_record, ip_address, psc_endpoint, state).
       - name: policy_engine
         description: The full google_vertex_ai_semantic_governance_policy_engine resource object.
   requirements:
@@ -100,4 +114,4 @@ spec:
       - dlp.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.41.0, < 8"
+        version: ">= 8.1.0, < 9"

--- a/modules/semantic-governance-policy-engine/outputs.tf
+++ b/modules/semantic-governance-policy-engine/outputs.tf
@@ -19,12 +19,11 @@ output "policy_engine" {
   value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine
 }
 
-# gateway_configs is a set on the resource, so it cannot be indexed by name.
-# Re-key it into a map (mirroring the gateway_configs input) so a caller can
-# read one gateway by name -- e.g. gateway_endpoints["<name>"].dns_record. Each
-# value is the full gateway object: the inputs plus the computed fields
-# (state, ip_address, psc_endpoint, dns_record).
+# gateway_configs is a set on the resource, which cannot be indexed. Expose it
+# as a list -- not a name-keyed map -- so consumers can select a gateway by
+# positional index (e.g. gateway_endpoints[0].dns_record); Application Design
+# Center connections support positional index but not string-key map access.
 output "gateway_endpoints" {
-  description = "Map of gateway name to its full gateway object (the inputs plus the computed fields dns_record, ip_address, psc_endpoint, state)."
-  value       = { for g in google_vertex_ai_semantic_governance_policy_engine.policy_engine.gateway_configs : g.name => g }
+  description = "List of gateway objects (each with the inputs plus the computed fields dns_record, ip_address, psc_endpoint, state)."
+  value       = tolist(google_vertex_ai_semantic_governance_policy_engine.policy_engine.gateway_configs)
 }

--- a/modules/semantic-governance-policy-engine/outputs.tf
+++ b/modules/semantic-governance-policy-engine/outputs.tf
@@ -18,3 +18,13 @@ output "policy_engine" {
   description = "The full google_vertex_ai_semantic_governance_policy_engine resource object."
   value       = google_vertex_ai_semantic_governance_policy_engine.policy_engine
 }
+
+# gateway_configs is a set on the resource, so it cannot be indexed by name.
+# Re-key it into a map (mirroring the gateway_configs input) so a caller can
+# read one gateway by name -- e.g. gateway_endpoints["<name>"].dns_record. Each
+# value is the full gateway object: the inputs plus the computed fields
+# (state, ip_address, psc_endpoint, dns_record).
+output "gateway_endpoints" {
+  description = "Map of gateway name to its full gateway object (the inputs plus the computed fields dns_record, ip_address, psc_endpoint, state)."
+  value       = { for g in google_vertex_ai_semantic_governance_policy_engine.policy_engine.gateway_configs : g.name => g }
+}

--- a/modules/semantic-governance-policy-engine/variables.tf
+++ b/modules/semantic-governance-policy-engine/variables.tf
@@ -35,7 +35,7 @@ variable "deletion_policy" {
 }
 
 variable "gateway_configs" {
-  description = "Customer-VPC PSC gateway configurations, keyed by gateway name (at most 5). Each entry provisions a Private Service Connect endpoint. Within an entry, network, subnetwork, and dns_zone_name must all be set together or all omitted (a partial set is rejected); when set, network and subnetwork are full resource URIs and dns_zone_name is the private Cloud DNS zone the gateway's A-record is published into. allowed_projects (optional) enables decoupled mode and takes full 'projects/{id}' resource names."
+  description = "Customer-VPC PSC gateway configurations, keyed by gateway name (at most 5). Each entry provisions a Private Service Connect endpoint. Within an entry, network, subnetwork, and dns_zone_name must all be set together or all omitted (a partial set is rejected); when set, network and subnetwork are the resources' .id (not .self_link, which the API rejects) and dns_zone_name is the private Cloud DNS zone the gateway's A-record is published into. allowed_projects (optional) takes full 'projects/{id}' resource names."
   type = map(object({
     network          = optional(string)
     subnetwork       = optional(string)

--- a/modules/semantic-governance-policy-engine/variables.tf
+++ b/modules/semantic-governance-policy-engine/variables.tf
@@ -33,3 +33,20 @@ variable "deletion_policy" {
     error_message = "deletion_policy must be one of DELETE, PREVENT, or ABANDON."
   }
 }
+
+variable "gateway_configs" {
+  description = "Customer-VPC PSC gateway configurations, keyed by gateway name (at most 5). Each entry provisions a Private Service Connect endpoint. Within an entry, network, subnetwork, and dns_zone_name must all be set together or all omitted (a partial set is rejected); when set, network and subnetwork are full resource URIs and dns_zone_name is the private Cloud DNS zone the gateway's A-record is published into. allowed_projects (optional) enables decoupled mode and takes full 'projects/{id}' resource names."
+  type = map(object({
+    network          = optional(string)
+    subnetwork       = optional(string)
+    dns_zone_name    = optional(string)
+    allowed_projects = optional(list(string))
+  }))
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = length(var.gateway_configs) <= 5
+    error_message = "At most 5 gateway_configs are allowed."
+  }
+}

--- a/modules/semantic-governance-policy-engine/versions.tf
+++ b/modules/semantic-governance-policy-engine/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.41.0, < 9"
+      version = ">= 8.1.0, < 9"
     }
   }
   provider_meta "google" {

--- a/modules/semantic-governance-policy-engine/versions.tf
+++ b/modules/semantic-governance-policy-engine/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 8.1.0, < 9"
+      version = ">= 8.1, < 9"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
## Summary

Adds a `gateway_configs` input to the `semantic-governance-policy-engine` sub-module, wiring customer-VPC Private Service Connect (PSC) gateways into the `google_vertex_ai_semantic_governance_policy_engine` resource.

- New `gateway_configs` variable: `map(object({ network, subnetwork, dns_zone_name, allowed_projects }))`, keyed by gateway name, `default = {}`, `nullable = false`, at most 5 entries. Within an entry, `network` / `subnetwork` / `dns_zone_name` must be set together or all omitted (a partial set is rejected); `allowed_projects` takes full `projects/{id}` names (decoupled mode).
- Matching `dynamic "gateway_configs"` block in `main.tf`.
- SGPE provider floor raised `>= 7.41.0` → `>= 8.1.0` (see below).
- New `gateway_endpoints` output (map of gateway name → its full gateway object).
- New `semantic-governance-policy-engine-gateway-example` (validated, not CI-applied).

## ⚠️ Breaking change — requires provider 8.x (major bump)

**Deliberately released as `feat!`.** `gateway_configs` shipped in the `hashicorp/google` provider in **v8.1.0**, so this module's provider floor moves up:

```diff
-      version = ">= 7.41.0, < 9"
+      version = ">= 8.1.0, < 9"
```

The repo already *allows* provider 8.x — the `< 9` ceiling landed repo-wide in #135. This change *requires* 8.1.0 for the `semantic-governance-policy-engine` module, dropping provider-7 support for it, which is breaking for any consumer of that module still on provider 7.x. In this single-version repo that warrants a major.

## Outputs

- **`policy_engine`** — the whole `google_vertex_ai_semantic_governance_policy_engine` resource; carries every per-gateway computed value (`state`, `ip_address`, `psc_endpoint`, `dns_record`).
- **`gateway_endpoints`** — a map of gateway name → the full gateway object (its inputs plus computed `dns_record`, `ip_address`, `psc_endpoint`, `state`), re-keyed from `policy_engine.gateway_configs` (a set, so not indexable by name). Read one field as `gateway_endpoints["<name>"].dns_record`. Exposing a whole-object output by name is consistent with the repo (e.g. `model-armor-template`'s `template`).

## Examples and docs

- The **minimal example** (`semantic-governance-policy-engine-example`) stays gateway-free — a live gateway would provision real PSC/DNS during module tests.
- A **new gateway example** (`semantic-governance-policy-engine-gateway-example`) demonstrates a full gateway: it creates the network, subnetwork, and private Cloud DNS zone and attaches one PSC gateway via `gateway_configs`, passing network/subnetwork as their full resource URIs (the resources' `.id`) so the config does not churn. It is **not** wired into `build/int.cloudbuild.yaml`, so it is validated but not applied in CI (the engine + PSC + DNS provision is long-running).
- `gateway_configs` is also documented via the module README Inputs table (auto-generated from the variable description).

## Validation

- **Module**: `terraform init` with provider **8.1.x** + `terraform validate` → **Success**. The `gateway_configs` block was checked against the live provider 8.1.0 schema — settable `name` / `network` / `subnetwork` / `dns_zone_name` / `allowed_projects`, computed `state` / `ip_address` / `psc_endpoint` / `dns_record`.
- **Gateway example**: `terraform validate` against provider **8.2.0** with the local module → **Success**. Not applied in CI.
- **Example resolution**: the examples source the module by registry path with no version pin; a local `terraform validate` resolves the published module, while CI's `module-swapper` rewrites the examples to the local module for init/plan.
